### PR TITLE
add @timestamp type

### DIFF
--- a/_meta/fields.yml
+++ b/_meta/fields.yml
@@ -6,6 +6,8 @@
       type: keyword
     - name: group
       type: keyword
+    - name: "@timestamp"
+      type: date
     - name: topic
       fields:
         - name: name


### PR DESCRIPTION
Hi,
When I sent data to elasticsearch and used it as a datasource in grafana dashboard, I got a error 
 from grafana: “Can't parse the @timestamp field of type keyword". I checked the mapping of the index, the type of @timestamp field was really "keyword". Finally I declared the date type  in field.xml and then fix the error.
 